### PR TITLE
Verify proposer payment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,25 +26,25 @@ jobs:
           components: rustfmt, clippy
 
       - name: cargo check
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo
         with:
           command: check
           args: --all --all-features --benches --tests
 
       - name: cargo fmt
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo
         with:
           command: fmt
           args: --all --check
 
       - name: cargo clippy
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo
         with:
           command: clippy
           args: --all --all-features --benches --tests
 
       - name: cargo test
-        uses: actions-rs/cargo@v1
+        uses: actions-rs/cargo
         with:
           command: test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
       - name: Install toolchain
-        uses: dtolnay/rust-toolchain@nightly
+        uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,27 +24,5 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-
       - name: cargo check
-        uses: actions-rs/cargo
-        with:
-          command: check
-          args: --all --all-features --benches --tests
-
-      - name: cargo fmt
-        uses: actions-rs/cargo
-        with:
-          command: fmt
-          args: --all --check
-
-      - name: cargo clippy
-        uses: actions-rs/cargo
-        with:
-          command: clippy
-          args: --all --all-features --benches --tests
-
-      - name: cargo test
-        uses: actions-rs/cargo
-        with:
-          command: test
-
+        run: cargo check --all --tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,5 +24,18 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+
       - name: cargo check
-        run: cargo check --all --tests
+        run: cargo check --all --all-features --benches --tests
+
+      - name: cargo fmt
+        run: cargo fmt --all --check
+
+      - name: cargo clippy
+        run: cargo clippy --all --all-features --benches --tests
+
+      - name: cargo test
+        run: cargo test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,6 @@ jobs:
         uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt, clippy
-      - uses: Swatinem/rust-cache@v2
-        with:
-          cache-on-failure: true
 
       - name: cargo check
         uses: actions-rs/cargo@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1888,7 +1888,7 @@ dependencies = [
  "log",
  "rand 0.8.5",
  "rlp",
- "secp256k1",
+ "secp256k1 0.27.0",
  "serde",
  "sha3",
  "zeroize",
@@ -4446,7 +4446,7 @@ dependencies = [
  "reth-tracing",
  "reth-transaction-pool",
  "reth-trie",
- "secp256k1",
+ "secp256k1 0.27.0",
  "serde",
  "serde_json",
  "shellexpand",
@@ -4537,6 +4537,7 @@ dependencies = [
  "hex",
  "jsonrpsee",
  "reth",
+ "secp256k1 0.28.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -4587,7 +4588,7 @@ dependencies = [
  "reth-network",
  "reth-primitives",
  "reth-stages",
- "secp256k1",
+ "secp256k1 0.27.0",
  "serde",
  "serde_json",
  "tempfile",
@@ -4651,7 +4652,7 @@ dependencies = [
  "reth-net-nat",
  "reth-primitives",
  "rlp",
- "secp256k1",
+ "secp256k1 0.27.0",
  "serde",
  "thiserror",
  "tokio",
@@ -4673,7 +4674,7 @@ dependencies = [
  "reth-net-common",
  "reth-primitives",
  "schnellru",
- "secp256k1",
+ "secp256k1 0.27.0",
  "serde",
  "serde_with",
  "thiserror",
@@ -4728,7 +4729,7 @@ dependencies = [
  "rand 0.8.5",
  "reth-net-common",
  "reth-primitives",
- "secp256k1",
+ "secp256k1 0.27.0",
  "sha2",
  "sha3",
  "thiserror",
@@ -4784,7 +4785,7 @@ dependencies = [
  "reth-primitives",
  "reth-rpc-types",
  "revm-primitives",
- "secp256k1",
+ "secp256k1 0.27.0",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -4916,7 +4917,7 @@ dependencies = [
  "reth-rpc-types",
  "reth-tasks",
  "reth-transaction-pool",
- "secp256k1",
+ "secp256k1 0.27.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -5007,7 +5008,7 @@ dependencies = [
  "rayon",
  "reth-codecs",
  "revm-primitives",
- "secp256k1",
+ "secp256k1 0.27.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -5144,7 +5145,7 @@ dependencies = [
  "revm",
  "revm-primitives",
  "schnellru",
- "secp256k1",
+ "secp256k1 0.27.0",
  "serde",
  "serde_json",
  "thiserror",
@@ -5383,7 +5384,7 @@ dependencies = [
  "once_cell",
  "revm-primitives",
  "ripemd",
- "secp256k1",
+ "secp256k1 0.27.0",
  "sha2",
  "substrate-bn",
 ]
@@ -5697,8 +5698,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
 dependencies = [
  "rand 0.8.5",
- "secp256k1-sys",
+ "secp256k1-sys 0.8.1",
  "serde",
+]
+
+[[package]]
+name = "secp256k1"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acea373acb8c21ecb5a23741452acd2593ed44ee3d343e72baaa143bc89d0d5"
+dependencies = [
+ "rand 0.8.5",
+ "secp256k1-sys 0.9.0",
 ]
 
 [[package]]
@@ -5706,6 +5717,15 @@ name = "secp256k1-sys"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09e67c467c38fd24bd5499dc9a18183b31575c12ee549197e3e20d57aa4fe3b7"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ eyre = "0.6.8"
 hex = "0.4.3"
 jsonrpsee = "0.20.1"
 reth = { git = "https://github.com/paradigmxyz/reth", commit = "fd697d9d3f1574f3bfd1fba8c45acddca4461731"}
+secp256k1 = { version = "0.28.0", features = ["rand-std"] }
 serde = "1.0.188"
 serde_json = "1.0.107"
 serde_with = "3.3.0"

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -71,6 +71,7 @@ where
         let unsealed_block = block.clone().unseal();
         // Note: Setting total difficulty to U256::MAX makes this incompatible with pre merge POW
         // blocks
+        // TODO: Check what exactly the "senders" argument is and if we can set it to None here
         executor
             .execute_and_verify_receipt(&unsealed_block, U256::MAX, None)
             .map_err(|e| internal_rpc_err(format!("Error executing transactions: {:}", e)))?;

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -100,13 +100,17 @@ fn check_proposer_payment_in_last_transaction(
     expected_payment: &U256,
 ) -> RpcResult<()> {
     if receipts.is_empty() || receipts[0].is_empty() {
-        return Err(internal_rpc_err("No receipts in block to verify proposer payment"));
+        return Err(internal_rpc_err(
+            "No receipts in block to verify proposer payment",
+        ));
     }
     let receipts = &receipts[0];
 
     let num_transactions = transactions.len();
     if num_transactions == 0 {
-        return Err(internal_rpc_err("No transactions in block to verify proposer payment"));
+        return Err(internal_rpc_err(
+            "No transactions in block to verify proposer payment",
+        ));
     }
     if num_transactions != receipts.len() {
         return Err(internal_rpc_err(format!(

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -16,7 +16,7 @@ use std::sync::Arc;
 use crate::ValidationApi;
 
 mod types;
-pub use types::ValidationRequestBody;
+pub use types::*;
 
 mod result;
 use result::internal_rpc_err;

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -4,8 +4,8 @@ use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth::consensus_common::validation::full_validation;
 use reth::primitives::{Address, ChainSpec, Receipts, SealedBlock, TransactionSigned, U256};
 use reth::providers::{
-    AccountReader, BlockExecutor, BlockReaderIdExt, ChainSpecProvider,
-    HeaderProvider, StateProviderFactory, WithdrawalsProvider,
+    AccountReader, BlockExecutor, BlockReaderIdExt, ChainSpecProvider, HeaderProvider,
+    StateProviderFactory, WithdrawalsProvider,
 };
 use reth::revm::{database::StateProviderDatabase, db::BundleState, processor::EVMProcessor};
 use reth::rpc::compat::engine::payload::try_into_sealed_block;

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -80,6 +80,7 @@ where
             fee_recipient,
             expected_payment,
         )? {
+            println!("Proposer payment verified by balance check");
             return Ok(());
         }
 
@@ -99,13 +100,13 @@ fn check_proposer_payment_in_last_transaction(
     expected_payment: &U256,
 ) -> RpcResult<()> {
     if receipts.is_empty() || receipts[0].is_empty() {
-        return Err(internal_rpc_err("No receipts in block"));
+        return Err(internal_rpc_err("No receipts in block to verify proposer payment"));
     }
     let receipts = &receipts[0];
 
     let num_transactions = transactions.len();
     if num_transactions == 0 {
-        return Err(internal_rpc_err("No transactions in block"));
+        return Err(internal_rpc_err("No transactions in block to verify proposer payment"));
     }
     if num_transactions != receipts.len() {
         return Err(internal_rpc_err(format!(
@@ -158,10 +159,19 @@ fn check_proposer_balance_change(
         .info
         .clone()
         .ok_or_else(|| internal_rpc_err("Fee recipient account info not found"))?;
+    println!(
+        "Fee receiver balance after: {:}",
+        fee_receiver_account_after.balance
+    );
     let fee_receiver_account_before = fee_receiver_account_state
         .original_info
         .clone()
         .ok_or_else(|| internal_rpc_err("Fee recipient original account info not found"))?;
+    println!(
+        "Fee receiver balance before: {:}",
+        fee_receiver_account_before.balance
+    );
+    println!("Expected payment: {:}", expected_payment);
 
     Ok(fee_receiver_account_after.balance
         >= (fee_receiver_account_before.balance + expected_payment))

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -2,7 +2,10 @@ use async_trait::async_trait;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 use reth::consensus_common::validation::full_validation;
-use reth::primitives::{Address, ChainSpec, Receipts, SealedBlock, TransactionSigned, U256, revm_primitives::AccountInfo};
+use reth::primitives::{
+    revm_primitives::AccountInfo, Address, ChainSpec, Receipts, SealedBlock, TransactionSigned,
+    U256,
+};
 use reth::providers::{
     AccountReader, BlockExecutor, BlockReaderIdExt, ChainSpecProvider, HeaderProvider,
     StateProviderFactory, WithdrawalsProvider,

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -169,8 +169,7 @@ fn check_proposer_balance_change(
         None => return false,
     };
 
-    fee_receiver_account_after.balance
-        >= (fee_receiver_account_before.balance + expected_payment)
+    fee_receiver_account_after.balance >= (fee_receiver_account_before.balance + expected_payment)
 }
 
 #[async_trait]

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -69,12 +69,11 @@ where
         let mut executor =
             EVMProcessor::new_with_db(chain_spec, StateProviderDatabase::new(state_provider));
 
-        let td = self.provider().header_td(&block.parent_hash).to_rpc_result()?.ok_or_else(
-            || internal_rpc_err(format!("Parent block {:?} not found", block.parent_hash)),
-        )?;
         let unsealed_block = block.clone().unseal();
+        // Note: Setting total difficulty to U256::MAX makes this incompatible with pre merge POW
+        // blocks
         executor
-            .execute_and_verify_receipt(&unsealed_block, td.add(block.difficulty), None)
+            .execute_and_verify_receipt(&unsealed_block, U256::MAX, None)
             .map_err(|e| internal_rpc_err(format!("Error executing transactions: {:}", e)))?;
 
         let output_state = executor.take_output_state();

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 
 use reth::consensus_common::validation::full_validation;
-use reth::primitives::{Address, ChainSpec, Receipts, SealedBlock, TransactionSigned, U256};
+use reth::primitives::{Address, ChainSpec, Receipts, SealedBlock, TransactionSigned, U256, revm_primitives::AccountInfo};
 use reth::providers::{
     AccountReader, BlockExecutor, BlockReaderIdExt, ChainSpecProvider, HeaderProvider,
     StateProviderFactory, WithdrawalsProvider,
@@ -167,7 +167,7 @@ fn check_proposer_balance_change(
     };
     let fee_receiver_account_before = match fee_receiver_account_state.original_info.clone() {
         Some(account) => account,
-        None => return false,
+        None => AccountInfo::default(), // TODO: In tests with the MockProvider this was None by default, check if this fallback is needed in production
     };
 
     fee_receiver_account_after.balance >= (fee_receiver_account_before.balance + expected_payment)

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -4,7 +4,7 @@ use jsonrpsee::{core::RpcResult, proc_macros::rpc};
 use reth::consensus_common::validation::full_validation;
 use reth::primitives::{Address, ChainSpec, Receipts, SealedBlock, TransactionSigned, U256};
 use reth::providers::{
-    AccountReader, BlockExecutor, BlockReaderIdExt, ChainSpecProvider, ChangeSetReader,
+    AccountReader, BlockExecutor, BlockReaderIdExt, ChainSpecProvider,
     HeaderProvider, StateProviderFactory, WithdrawalsProvider,
 };
 use reth::revm::{database::StateProviderDatabase, db::BundleState, processor::EVMProcessor};
@@ -39,7 +39,6 @@ impl<Provider> ValidationApi<Provider>
 where
     Provider: BlockReaderIdExt
         + ChainSpecProvider
-        + ChangeSetReader
         + StateProviderFactory
         + HeaderProvider
         + AccountReader
@@ -173,7 +172,6 @@ impl<Provider> ValidationApiServer for ValidationApi<Provider>
 where
     Provider: BlockReaderIdExt
         + ChainSpecProvider
-        + ChangeSetReader
         + StateProviderFactory
         + HeaderProvider
         + AccountReader

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -4,7 +4,7 @@ use reth::rpc::types::{ExecutionPayload, ExecutionPayloadV1, ExecutionPayloadV2,
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub struct ValidationRequestBody {
     pub execution_payload: ExecutionPayloadValidation,
@@ -14,7 +14,7 @@ pub struct ValidationRequestBody {
 }
 
 #[serde_as]
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub struct BidTrace {
     #[serde_as(as = "DisplayFromStr")]
@@ -37,7 +37,7 @@ pub struct BidTrace {
 #[serde_as]
 #[derive(Derivative)]
 #[derivative(Debug)]
-#[derive(Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub struct ExecutionPayloadValidation {
     pub parent_hash: B256,

--- a/tests/integration/http.rs
+++ b/tests/integration/http.rs
@@ -132,7 +132,7 @@ async fn test_missing_proposer_payment() {
     )
     .await;
 
-    let expected_message = "Fee recipient account not found";
+    let expected_message = "No receipts in block to verify proposer payment";
     let error_message = get_call_error_message(result.unwrap_err()).unwrap();
     assert_eq!(error_message, expected_message);
 }

--- a/tests/integration/http.rs
+++ b/tests/integration/http.rs
@@ -77,6 +77,8 @@ async fn test_valid_block_proposer_payment_not_last() {
         }),
     );
 
+    // By adding additional transactions to the end we make sure that the reward is checked via the
+    // block balance change
     validation_request_body = seal_request_body(add_transactions(validation_request_body, vec![other_transaction], provider));
     println!("request_body_tx: {:#?}", validation_request_body.execution_payload.transactions);
 

--- a/tests/integration/http.rs
+++ b/tests/integration/http.rs
@@ -4,14 +4,15 @@ use jsonrpsee::{
     server::ServerBuilder,
 };
 use reth::providers::test_utils::MockEthProvider;
-use reth_block_validator::rpc::{ValidationApiClient, ValidationApiServer, ValidationRequestBody};
+use reth::primitives::{Address, Block, Bloom, Bytes, Header, B256, U256};
+use reth_block_validator::rpc::{BidTrace, ExecutionPayloadValidation, ValidationApiClient, ValidationApiServer, ValidationRequestBody};
 use reth_block_validator::ValidationApi;
 
 const VALIDATION_REQUEST_BODY: &str = include_str!("../../tests/data/single_payload.json");
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_unknown_parent_hash() {
-    let client = get_client().await;
+    let client = get_client(None).await;
     let validation_request_body: ValidationRequestBody =
         serde_json::from_str(VALIDATION_REQUEST_BODY).unwrap();
     let result = ValidationApiClient::validate_builder_submission_v2(
@@ -28,8 +29,80 @@ async fn test_unknown_parent_hash() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_valid_block() {
+    let provider = MockEthProvider::default();
+    let client = get_client(Some(provider.clone())).await;
+
+    let base_fee_per_gas = 1_000_000_000;
+    let block = Block {
+        header: Header {
+            parent_hash: B256::default(),
+            beneficiary: Address::default(),
+            logs_bloom: Bloom::default(),
+            mix_hash: B256::default(),
+            ommers_hash: B256::default(),
+            receipts_root: B256::default(),
+            state_root: B256::default(),
+            transactions_root: B256::default(),
+            withdrawals_root: Some(B256::default()),
+            parent_beacon_block_root: None,
+            blob_gas_used: None,
+            excess_blob_gas: None,
+            extra_data: Bytes::default(),
+            timestamp: 0,
+            number: 0,
+            gas_limit: 0,
+            gas_used: 0,
+            difficulty: U256::from(0),
+            base_fee_per_gas: Some(base_fee_per_gas),
+            nonce: 0,
+        },
+        body: vec![],
+        ommers: vec![],
+        withdrawals: Some(vec![]),
+    };
+
+    let block_hash = block.header.hash_slow();
+
+
+    let mut validation_request_body = ValidationRequestBody {
+        execution_payload: ExecutionPayloadValidation {
+            parent_hash: block.header.parent_hash,
+            state_root: block.header.state_root,
+            receipts_root: block.header.receipts_root,
+            logs_bloom: block.header.logs_bloom,
+            gas_used: block.header.gas_used,
+            gas_limit: block.header.gas_limit,
+            timestamp: block.header.timestamp,
+            extra_data: block.header.extra_data,
+            base_fee_per_gas: U256::from(block.header.base_fee_per_gas.unwrap()),
+            block_hash,
+            block_number: block.header.number,
+            fee_recipient: block.header.beneficiary,
+            transactions: vec![],
+            withdrawals:  vec![],
+            prev_randao: B256::default(),
+        },
+        message: BidTrace::default(),
+        registered_gas_limit: 0.to_string(),
+        signature: Bytes::default(),
+    };
+        
+        
+
+
+    validation_request_body.execution_payload.base_fee_per_gas = U256::from(base_fee_per_gas);
+    println!("validation_request_body: {:?}", validation_request_body);
+    let result = ValidationApiClient::validate_builder_submission_v2(
+        &client,
+        validation_request_body.clone(),
+    ).await;
+    println!("result: {:?}", result);
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_wrong_hash() {
-    let client = get_client().await;
+    let client = get_client(None).await;
 
     let validation_request_body: ValidationRequestBody =
         serde_json::from_str(VALIDATION_REQUEST_BODY).unwrap();
@@ -48,16 +121,16 @@ async fn test_wrong_hash() {
     assert!(error_message.contains("blockhash mismatch"));
 }
 
-async fn get_client() -> HttpClient {
-    let server_addr = start_server().await;
+async fn get_client(provider: Option<MockEthProvider>) -> HttpClient {
+    let server_addr = start_server(provider).await;
     let uri = format!("http://{}", server_addr);
     HttpClientBuilder::default().build(uri).unwrap()
 }
 
-async fn start_server() -> std::net::SocketAddr {
+async fn start_server(provider: Option<MockEthProvider>) -> std::net::SocketAddr {
     let server = ServerBuilder::default().build("127.0.0.1:0").await.unwrap();
     let addr = server.local_addr().unwrap();
-    let provider = MockEthProvider::default();
+    let provider = provider.unwrap_or_default();
     let api = ValidationApi::new(provider);
     let server_handle = server.start(api.into_rpc());
 

--- a/tests/integration/http.rs
+++ b/tests/integration/http.rs
@@ -1,3 +1,4 @@
+use std::time::{SystemTime, UNIX_EPOCH};
 use jsonrpsee::{
     core::error::Error,
     http_client::{HttpClient, HttpClientBuilder},
@@ -35,12 +36,20 @@ async fn test_valid_block() {
     let client = get_client(Some(provider.clone())).await;
 
     let base_fee_per_gas = 1_000_000_000;
+    let start = SystemTime::now();
+    let timestamp = start
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards")
+        .as_secs();
+    println!("timestamp: {:?}", timestamp);
 
     let mut validation_request_body = ValidationRequestBody::default();
     validation_request_body.execution_payload.base_fee_per_gas = U256::from(base_fee_per_gas);
+    validation_request_body.execution_payload.timestamp = timestamp;
     let block = try_into_block(validation_request_body.execution_payload.clone().into(), None).expect("failed to create block");
     let sealed_block = block.seal_slow();
     validation_request_body.execution_payload.block_hash = sealed_block.hash();
+    validation_request_body.message.block_hash = sealed_block.hash();
         
         
 

--- a/tests/integration/http.rs
+++ b/tests/integration/http.rs
@@ -3,7 +3,7 @@ use jsonrpsee::{
     http_client::{HttpClient, HttpClientBuilder},
     server::ServerBuilder,
 };
-use reth::providers::test_utils::NoopProvider;
+use reth::providers::test_utils::MockEthProvider;
 use reth_block_validator::rpc::{ValidationApiClient, ValidationApiServer, ValidationRequestBody};
 use reth_block_validator::ValidationApi;
 
@@ -57,7 +57,7 @@ async fn get_client() -> HttpClient {
 async fn start_server() -> std::net::SocketAddr {
     let server = ServerBuilder::default().build("127.0.0.1:0").await.unwrap();
     let addr = server.local_addr().unwrap();
-    let provider = NoopProvider::default();
+    let provider = MockEthProvider::default();
     let api = ValidationApi::new(provider);
     let server_handle = server.start(api.into_rpc());
 

--- a/tests/integration/http.rs
+++ b/tests/integration/http.rs
@@ -9,9 +9,7 @@ use reth::{
     providers::test_utils::{ExtendedAccount, MockEthProvider},
     revm::primitives::FixedBytes,
 };
-use reth_block_validator::rpc::{
-    ExecutionPayloadValidation, ValidationApiClient, ValidationApiServer, ValidationRequestBody,
-};
+use reth_block_validator::rpc::{ValidationApiClient, ValidationApiServer, ValidationRequestBody};
 use reth_block_validator::ValidationApi;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -166,15 +164,16 @@ fn add_block(provider: MockEthProvider, gas_limit: u64, base_fee_per_gas: u64) -
     let block = generate_block(gas_limit, base_fee_per_gas);
     let block_hash = block.header.hash_slow();
     provider.add_block(block_hash, block.clone());
-    return block;
+    block
 }
 
 fn generate_block(gas_limit: u64, base_fee_per_gas: u64) -> Block {
-    let mut payload = ExecutionPayloadValidation::default();
-    payload.gas_limit = gas_limit;
-    payload.base_fee_per_gas = U256::from(base_fee_per_gas);
-    let block = try_into_block(payload.clone().into(), None).expect("failed to create block");
-    block
+    let payload = reth_block_validator::rpc::ExecutionPayloadValidation {
+        gas_limit,
+        base_fee_per_gas: U256::from(base_fee_per_gas),
+        ..Default::default()
+    };
+    try_into_block(payload.clone().into(), None).expect("failed to create block")
 }
 
 fn generate_validation_request_body(

--- a/tests/integration/http.rs
+++ b/tests/integration/http.rs
@@ -42,7 +42,7 @@ async fn test_valid_block() {
     let provider = MockEthProvider::default();
     let client = get_client(Some(provider.clone())).await;
 
-    let base_fee_per_gas = 1_000_000_000;
+    let base_fee_per_gas = 875000000;
     let start = SystemTime::now();
     let timestamp = start
         .duration_since(UNIX_EPOCH)
@@ -63,7 +63,7 @@ async fn test_valid_block() {
         parent_block_hash,
         fee_recipient,
         timestamp + 10,
-        base_fee_per_gas,
+        765625000,
         proposer_payment,
     );
 
@@ -82,7 +82,7 @@ async fn test_missing_proposer_payment() {
     let provider = MockEthProvider::default();
     let client = get_client(Some(provider.clone())).await;
 
-    let base_fee_per_gas = 1_000_000_000;
+    let base_fee_per_gas = 875000000;
     let start = SystemTime::now();
     let timestamp = start
         .duration_since(UNIX_EPOCH)
@@ -104,7 +104,7 @@ async fn test_missing_proposer_payment() {
         parent_block_hash,
         fee_recipient,
         timestamp + 10,
-        base_fee_per_gas,
+        765625000,
         proposer_payment,
     );
 
@@ -176,6 +176,7 @@ fn generate_block(gas_limit: u64, base_fee_per_gas: u64) -> Block {
     let payload = reth_block_validator::rpc::ExecutionPayloadValidation {
         gas_limit,
         base_fee_per_gas: U256::from(base_fee_per_gas),
+        block_number: 18469910,
         ..Default::default()
     };
     try_into_block(payload.clone().into(), None).expect("failed to create block")


### PR DESCRIPTION
This PR adds logic to verify the proposer is paid the reward specified in the payload.

Basically this is checked in two ways:
1. The change in the proposers balance at the beginning and end of the block is compared. If this change is greater or equal the reward it is accepted.
2. If step 1 failed the last transaction of the block is examined. If this is an eth transfer with the required amount sent to the proposer the payload is accepted.

This logic should be equivalent to [ what is done in the flashbots builder](https://github.com/flashbots/builder/blob/7f43d0b11e9020de70421bdc592c145e995a54a7/core/blockchain.go#L2566).

Also this PR adds tests, that build a valid payload from scratch (instead of loading the example data) and then change various aspects of it to verify the validation behaves correctly.

closes #7