### PR TITLE
Check if gas limit is in line with the value registered by the proposer

### DIFF
--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -128,16 +128,9 @@ where
                     "Parent block with hash {} not found",
                     parent_hash
                 )))?;
-        if registered_gas_limit == 0
-            && block_gas_limit == calc_gas_limit(parent.gas_limit, 30_000_000)
+        if registered_gas_limit != 0
+            || block_gas_limit != calc_gas_limit(parent.gas_limit, 30_000_000)
         {
-            // Prysm has a bug where it registers validators with a desired gas limit
-            // of 0. Some builders treat these as desiring gas limit 30_000_000. As a
-            // workaround, whenever the desired gas limit is 0, we accept both the
-            // limit as calculated with a desired limit of 0, and builders which fall
-            // back to calculating with the default 30_000_000.
-            return Ok(());
-        } else {
             let calculated_gas_limit = calc_gas_limit(parent.gas_limit, registered_gas_limit);
             if calculated_gas_limit != block_gas_limit {
                 return Err(internal_rpc_err(format!(

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -128,6 +128,13 @@ where
                     "Parent block with hash {} not found",
                     parent_hash
                 )))?;
+
+        // Prysm has a bug where it registers validators with a desired gas limit
+        // of 0. Some builders treat these as desiring gas limit 30_000_000. As a
+        // workaround, whenever the desired gas limit is 0, we accept both the
+        // limit as calculated with a desired limit of 0, and builders which fall
+        // back to calculating with the default 30_000_000.
+        // TODO: Review if we still need this
         if registered_gas_limit != 0
             || block_gas_limit != calc_gas_limit(parent.gas_limit, 30_000_000)
         {

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -135,18 +135,19 @@ where
         // limit as calculated with a desired limit of 0, and builders which fall
         // back to calculating with the default 30_000_000.
         // TODO: Review if we still need this
-        if registered_gas_limit != 0
-            || block_gas_limit != calc_gas_limit(parent.gas_limit, 30_000_000)
+        if registered_gas_limit == 0
+            && block_gas_limit == calc_gas_limit(parent.gas_limit, 30_000_000)
         {
-            let calculated_gas_limit = calc_gas_limit(parent.gas_limit, registered_gas_limit);
-            if calculated_gas_limit != block_gas_limit {
-                return Err(internal_rpc_err(format!(
-                    "Incorrect gas limit set, expected: {}, got: {}",
-                    calculated_gas_limit, block_gas_limit
-                )));
-            }
+            return Ok(());
         }
-        Ok(())
+        let calculated_gas_limit = calc_gas_limit(parent.gas_limit, registered_gas_limit);
+        if calculated_gas_limit == block_gas_limit {
+            return Ok(());
+        }
+        Err(internal_rpc_err(format!(
+            "Incorrect gas limit set, expected: {}, got: {}",
+            calculated_gas_limit, block_gas_limit
+        )))
     }
 }
 

--- a/src/rpc/types.rs
+++ b/src/rpc/types.rs
@@ -4,13 +4,15 @@ use reth::rpc::types::{ExecutionPayload, ExecutionPayloadV1, ExecutionPayloadV2,
 use serde::{Deserialize, Serialize};
 use serde_with::{serde_as, DisplayFromStr};
 
+#[serde_as]
 #[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub struct ValidationRequestBody {
     pub execution_payload: ExecutionPayloadValidation,
     pub message: BidTrace,
     pub signature: Bytes,
-    pub registered_gas_limit: String,
+    #[serde_as(as = "DisplayFromStr")]
+    pub registered_gas_limit: u64,
 }
 
 #[serde_as]

--- a/src/rpc/utils.rs
+++ b/src/rpc/utils.rs
@@ -1,5 +1,5 @@
-use jsonrpsee::core::RpcResult;
 use crate::rpc::result::internal_rpc_err;
+use jsonrpsee::core::RpcResult;
 
 pub fn compare_values<T: std::cmp::PartialEq + std::fmt::Display>(
     name: &str,
@@ -16,7 +16,7 @@ pub fn compare_values<T: std::cmp::PartialEq + std::fmt::Display>(
     }
 }
 
-// TODO: Can we avoid hard coding this here and read it from reth config instead ? 
+// TODO: Can we avoid hard coding this here and read it from reth config instead ?
 const GAS_LIMIT_BOUND_DIVISOR: u64 = 1024;
 const MIN_GAS_LIMIT: u64 = 5000;
 
@@ -37,6 +37,5 @@ pub fn calc_gas_limit(parent_gas_limit: u64, desired_limit: u64) -> u64 {
             limit = desired_limit;
         }
     }
-    return limit;
+    limit
 }
-

--- a/src/rpc/utils.rs
+++ b/src/rpc/utils.rs
@@ -1,0 +1,42 @@
+use jsonrpsee::core::RpcResult;
+use crate::rpc::result::internal_rpc_err;
+
+pub fn compare_values<T: std::cmp::PartialEq + std::fmt::Display>(
+    name: &str,
+    expected: T,
+    actual: T,
+) -> RpcResult<()> {
+    if expected != actual {
+        Err(internal_rpc_err(format!(
+            "incorrect {} {}, expected {}",
+            name, actual, expected
+        )))
+    } else {
+        Ok(())
+    }
+}
+
+// TODO: Can we avoid hard coding this here and read it from reth config instead ? 
+const GAS_LIMIT_BOUND_DIVISOR: u64 = 1024;
+const MIN_GAS_LIMIT: u64 = 5000;
+
+pub fn calc_gas_limit(parent_gas_limit: u64, desired_limit: u64) -> u64 {
+    let delta = parent_gas_limit / GAS_LIMIT_BOUND_DIVISOR - 1;
+    let mut limit = parent_gas_limit;
+    let desired_limit = std::cmp::max(desired_limit, MIN_GAS_LIMIT);
+    if limit < desired_limit {
+        limit = parent_gas_limit + delta;
+        if limit > desired_limit {
+            limit = desired_limit;
+        }
+        return limit;
+    }
+    if limit > desired_limit {
+        limit = parent_gas_limit - delta;
+        if limit < desired_limit {
+            limit = desired_limit;
+        }
+    }
+    return limit;
+}
+

--- a/src/rpc/utils.rs
+++ b/src/rpc/utils.rs
@@ -17,29 +17,26 @@ pub fn compare_values<T: std::cmp::PartialEq + std::fmt::Display>(
 }
 
 // TODO: Can we avoid hard coding this here and read it from reth config instead ?
+// Values as specified in: https://eips.ethereum.org/EIPS/eip-1559#specification
 const GAS_LIMIT_BOUND_DIVISOR: u64 = 1024;
 const MIN_GAS_LIMIT: u64 = 5000;
 
 // Compute the gas limit of the next block after parent. It aims
 // to keep the baseline gas close to the provided target, and increase it towards
 // the target if the baseline gas is lower.
-// Reference: https://github.com/flashbots/builder/blob/03ee71cf0a344397204f65ff6d3a917ee8e06724/core/utils/gas_limit.go#L8
+// Ported from: https://github.com/flashbots/builder/blob/03ee71cf0a344397204f65ff6d3a917ee8e06724/core/utils/gas_limit.go#L8
+// Reference implementation: https://eips.ethereum.org/EIPS/eip-1559#specification
 pub fn calc_gas_limit(parent_gas_limit: u64, desired_limit: u64) -> u64 {
+    // TODO: Understand why 1 is subtracted here
     let delta = parent_gas_limit / GAS_LIMIT_BOUND_DIVISOR - 1;
-    let mut limit = parent_gas_limit;
     let desired_limit = std::cmp::max(desired_limit, MIN_GAS_LIMIT);
-    if limit < desired_limit {
-        limit = parent_gas_limit + delta;
-        if limit > desired_limit {
-            limit = desired_limit;
-        }
-        return limit;
+    if parent_gas_limit < desired_limit {
+        let max_acceptable_limit = parent_gas_limit + delta;
+        std::cmp::min(max_acceptable_limit, desired_limit)
+    } else if parent_gas_limit > desired_limit {
+        let min_acceptable_limit = parent_gas_limit - delta;
+        std::cmp::max(min_acceptable_limit, desired_limit)
+    } else {
+        parent_gas_limit
     }
-    if limit > desired_limit {
-        limit = parent_gas_limit - delta;
-        if limit < desired_limit {
-            limit = desired_limit;
-        }
-    }
-    limit
 }

--- a/src/rpc/utils.rs
+++ b/src/rpc/utils.rs
@@ -20,6 +20,10 @@ pub fn compare_values<T: std::cmp::PartialEq + std::fmt::Display>(
 const GAS_LIMIT_BOUND_DIVISOR: u64 = 1024;
 const MIN_GAS_LIMIT: u64 = 5000;
 
+// Compute the gas limit of the next block after parent. It aims
+// to keep the baseline gas close to the provided target, and increase it towards
+// the target if the baseline gas is lower.
+// Reference: https://github.com/flashbots/builder/blob/03ee71cf0a344397204f65ff6d3a917ee8e06724/core/utils/gas_limit.go#L8
 pub fn calc_gas_limit(parent_gas_limit: u64, desired_limit: u64) -> u64 {
     let delta = parent_gas_limit / GAS_LIMIT_BOUND_DIVISOR - 1;
     let mut limit = parent_gas_limit;

--- a/tests/integration/http.rs
+++ b/tests/integration/http.rs
@@ -48,6 +48,25 @@ async fn test_valid_block() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_registered_gas_limit_too_low_block() {
+    let provider_factory = get_provider_factory();
+    let mut validation_request_body: ValidationRequestBody =
+        generate_valid_request(&provider_factory, None);
+    let client = get_client(provider_factory).await;
+
+    validation_request_body.registered_gas_limit = 10_000;
+
+    let result = ValidationApiClient::validate_builder_submission_v2(
+        &client,
+        validation_request_body.clone(),
+    )
+    .await;
+    println!("{:?}", result);
+    let error_message = get_call_error_message(result.unwrap_err()).unwrap();
+    assert!(error_message.contains("Incorrect gas limit set"));
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_invalid_state_root() {
     let provider_factory = get_provider_factory();
     let mut validation_request_body: ValidationRequestBody =

--- a/tests/integration/http.rs
+++ b/tests/integration/http.rs
@@ -162,7 +162,7 @@ async fn test_incorrect_parent() {
         validation_request_body.clone(),
     )
     .await;
-    let expected_message = format!("block parent [hash={:?}] is not known", new_parent_hash);
+    let expected_message = format!("Parent block with hash {:?} not found", new_parent_hash);
     let error_message = get_call_error_message(result.unwrap_err()).unwrap();
     assert_eq!(error_message, expected_message);
 }
@@ -601,6 +601,7 @@ fn generate_validation_request_body(
     validation_request_body.message.parent_hash = parent_block_hash;
     validation_request_body.message.value = U256::from(proposer_fee);
     validation_request_body.message.proposer_fee_recipient = fee_recipient;
+    validation_request_body.registered_gas_limit = 1_000_000;
 
     seal_request_body(add_transactions(
         validation_request_body,


### PR DESCRIPTION
Note: This introduces some inefficiency because we are getting the parent block and doing some gas check on it twice.
See [here](https://github.com/paradigmxyz/reth/blob/eadbe5dce967666c9d900bb0730c15e166fe60fe/crates/consensus/common/src/validation.rs#L325)