### PR TITLE
chore(docker): Fix Dockerfile by using nightly toolchain

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+    pull_request:
 
 jobs:
   docker:
@@ -27,8 +28,21 @@ jobs:
       - name: Extract short SHA
         run: echo "SHORT_SHA=$(echo ${{ github.sha }} | cut -c 1-7)" >> $GITHUB_ENV
 
+      - name: Build (without push)
+        uses: docker/build-push-action@v5
+        if: github.event_name == 'pull_request'
+        with:
+          context: .
+          push: false
+          tags: |
+            ultrasoundorg/payload-validator:${{ env.SHORT_SHA }}
+            ultrasoundorg/payload-validator:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
       - name: Build and push
         uses: docker/build-push-action@v5
+        if: github.event_name == 'pull_request'
         with:
           context: .
           push: true

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-    pull_request:
 
 jobs:
   docker:
@@ -28,21 +27,8 @@ jobs:
       - name: Extract short SHA
         run: echo "SHORT_SHA=$(echo ${{ github.sha }} | cut -c 1-7)" >> $GITHUB_ENV
 
-      - name: Build (without push)
-        uses: docker/build-push-action@v5
-        if: github.event_name == 'pull_request'
-        with:
-          context: .
-          push: false
-          tags: |
-            ultrasoundorg/payload-validator:${{ env.SHORT_SHA }}
-            ultrasoundorg/payload-validator:latest
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
       - name: Build and push
         uses: docker/build-push-action@v5
-        if: github.event_name == 'pull_request'
         with:
           context: .
           push: true

--- a/.github/workflows/check-lint-test.yaml
+++ b/.github/workflows/check-lint-test.yaml
@@ -39,3 +39,25 @@ jobs:
 
       - name: cargo test
         run: cargo +nightly test
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Extract short SHA
+        run: echo "SHORT_SHA=$(echo ${{ github.sha }} | cut -c 1-7)" >> $GITHUB_ENV
+
+      - name: Build (without push)
+        uses: docker/build-push-action@v5
+        if: github.event_name == 'pull_request'
+        with:
+          context: .
+          push: false
+          tags: |
+            ultrasoundorg/payload-validator:${{ env.SHORT_SHA }}
+            ultrasoundorg/payload-validator:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,12 +11,12 @@ COPY Cargo.toml Cargo.lock ./
 RUN mkdir src/
 RUN echo "fn main() {}" > dummy.rs
 RUN sed -i 's#src/main.rs#dummy.rs#' Cargo.toml
-RUN cargo build --release
+RUN cargo +nightly build --release
 
 # Build executable.
 RUN sed -i 's#dummy.rs#src/main.rs#' Cargo.toml
 COPY src ./src
-RUN cargo build --release
+RUN cargo +nightly build --release
 
 # Build runtime image.
 FROM gcr.io/distroless/cc-debian12 AS runtime

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ WORKDIR /app
 RUN apt-get update && apt-get -y upgrade && apt-get install -y libclang-dev pkg-config
 
 COPY Cargo.toml Cargo.lock ./
+RUN rustup install nightly
 RUN mkdir src/
 RUN echo "fn main() {}" > dummy.rs
 RUN sed -i 's#src/main.rs#dummy.rs#' Cargo.toml


### PR DESCRIPTION
https://github.com/ultrasoundmoney/reth-payload-validator/pull/20 requires us to use the nightly toolchain for a while, which is not yet reflected in the dockerfile leading to failing builds.

In addition this adds a check to the CI that verifies that the docker can be built on every pr.