### PR TITLE
refactor: make submission impl non blocking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6417,9 +6417,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.33.0"
+version = "1.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f38200e3ef7995e5ef13baec2f432a6da0aa9ac495b2c0e8f3b7eec2c92d653"
+checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6436,9 +6436,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
+checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ secp256k1 = { version = "0.28.0", features = ["rand-std"] }
 serde = "1.0.188"
 serde_json = "1.0.107"
 serde_with = "3.3.0"
+tokio = "1.35"
 uuid = "1.6.1"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,5 @@
-use std::sync::Arc;
-
-pub mod cli_ext;
 pub use cli_ext::ValidationCliExt;
 
+pub mod cli_ext;
 pub mod rpc;
-use rpc::ValidationApiInner;
-
-/// The type that implements the `validation` rpc namespace trait
-pub struct ValidationApi<Provider> {
-    inner: Arc<ValidationApiInner<Provider>>,
-}
+pub use rpc::ValidationApi;

--- a/src/rpc/api.rs
+++ b/src/rpc/api.rs
@@ -1,0 +1,16 @@
+use crate::rpc::ValidationRequestBody;
+use jsonrpsee::core::RpcResult;
+use jsonrpsee::proc_macros::rpc;
+
+/// trait interface for a custom rpc namespace: `validation`
+///
+/// This defines an additional namespace where all methods are configured as trait functions.
+#[rpc(client, server, namespace = "flashbots")]
+pub trait ValidationApi {
+    /// Validates a block submitted to the relay
+    #[method(name = "validateBuilderSubmissionV2")]
+    async fn validate_builder_submission_v2(
+        &self,
+        request_body: ValidationRequestBody,
+    ) -> RpcResult<()>;
+}


### PR DESCRIPTION
This is prep for additional performance improvements.

This moves some things around:

put API in API module
move `ValidationApi` to its impl


But most importantly this makes the validation part non blocking by spawning it via tokio::spawn_blocking.
previously this entire code section was in async code which should never block (CPU+blocking IO), because this negatively impacts the executor's performance.

Instead these jobs are now executed on the tokio threadpool that is allowed to block.